### PR TITLE
Fix variant ID data type from string to number in API

### DIFF
--- a/app/api/products/collection/[slug]/route.ts
+++ b/app/api/products/collection/[slug]/route.ts
@@ -55,7 +55,7 @@ export async function GET(
       
       // Transform variants to match the requested structure
       const transformedVariants = (product.variants || []).map((variant: any) => ({
-        id: variant.id,
+        id: Number(variant.id),
         title: variant.quantity || '',
         price: (variant.price || 0).toFixed(2),
         sku: variant.sku || `${handle.toUpperCase()}-${(variant.quantity || '').toUpperCase()}`,

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -35,7 +35,7 @@ export async function GET() {
 
       // Transform variants to match the requested structure
       const transformedVariants = (product.variants || []).map((variant: any) => ({
-        id: variant.id,
+        id: Number(variant.id),
         title: variant.quantity || '',
         price: (variant.price || 0).toFixed(2),
         sku: variant.sku || `${handle.toUpperCase()}-${(variant.quantity || '').toUpperCase()}`,


### PR DESCRIPTION
## Purpose
Fix catalog sync breaking issue by converting variant ID data type from string to number as required by the API specification.

## Code changes
- **File**: `app/api/products/collection/[slug]/route.ts`
  - Modified variant transformation to convert `variant.id` from string to number using `Number(variant.id)`
  
- **File**: `app/api/products/route.ts`  
  - Applied the same variant ID type conversion in the products API endpoint

Both changes ensure variant IDs are returned as numeric values instead of strings, resolving the catalog sync compatibility issue.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/712fb9277aed48d7be6e2f3fe1784140/vortex-world)

👀 [Preview Link](https://712fb9277aed48d7be6e2f3fe1784140-vortex-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>712fb9277aed48d7be6e2f3fe1784140</projectId>-->
<!--<branchName>vortex-world</branchName>-->